### PR TITLE
In the CheckProcess function, the check for whether the process  can run (need[i,j] > available[j]) is done, but there's no immediate exit after determining the process can't be executed. The flag f=1 is set, but the function continues to loop, checking the remaining resources.

### DIFF
--- a/os_project.bash
+++ b/os_project.bash
@@ -70,6 +70,7 @@ function CheckProcess {
     if [[ ${need[$1,$j]} -gt ${available[$j]} ]]
     then
       f=1
+      break
     fi
   done
   return $f


### PR DESCRIPTION
The flag f=1 is set, but the function continues to loop, checking the remaining resources. You should break out of the loop as soon as you find that a process cannot be executed, instead of continuing to check the rest of the resources. Add a break statement when f=1 is set: